### PR TITLE
feat: 메인 페이지 컴포넌트 구현

### DIFF
--- a/src/widgets/main/ui/SideMenu.tsx
+++ b/src/widgets/main/ui/SideMenu.tsx
@@ -1,0 +1,52 @@
+import cn from "@/shared/lib/cn";
+
+interface SideMenuProps {
+  categories: string[];
+  selectedCategory: string;
+  onSelect: (category: string) => void;
+}
+
+const SideMenu = ({
+  categories,
+  selectedCategory,
+  onSelect,
+}: SideMenuProps) => {
+  return (
+    <div
+      aria-labelledby="category-heading"
+      role="listbox"
+      className="flex flex-col gap-[4px] text-white"
+    >
+      <h2
+        id="category-heading"
+        className="pb-[20px] pl-[20px] text-[14px] leading-none font-normal xl:text-[16px]"
+      >
+        카테고리
+      </h2>
+      <ul className="scrollbar-none flex flex-row gap-[4px] overflow-x-auto md:flex-col">
+        {categories?.map((category) => (
+          <li key={category}>
+            <button
+              type="button"
+              role="option"
+              aria-selected={selectedCategory === category}
+              className={cn(
+                "flex h-[45px] w-[160px] items-center rounded-[8px] px-[20px] py-[15px]",
+                "text-[14px] leading-none font-medium transition-colors",
+                "focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none",
+                "xl:h-[50px] xl:w-[200px] xl:text-[16px]",
+                selectedCategory === category
+                  ? "border border-[#353542] bg-[#353542] text-white"
+                  : "text-[#6E6E82] hover:border hover:border-[#353542] hover:bg-[#252530] hover:text-white",
+              )}
+              onClick={() => onSelect(category)}
+            >
+              {category}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+export default SideMenu;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
closes #58 
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- SideMenu 컴포넌트 구현
### 스크린샷 (선택)
#### 모바일
상단 가로 스크롤
<img width="375" height="801" alt="image" src="https://github.com/user-attachments/assets/853b3c4d-3521-4dd5-9cfc-27a9b5f60302" />

#### 태블릿/데스크탑
왼쪽 사이드에 배치
<img width="1440" height="797" alt="image" src="https://github.com/user-attachments/assets/ac7484aa-f5b0-4448-a760-1dd3bb676970" />

## 💬리뷰 요구사항(선택)

> 리뷰어에게 미리 알려야 할 사항이 있다면 여기에 작성해주세요.
