### PR TITLE
유저 정보 조회 api 연동 및 프로필 수정 모달 적용

### DIFF
--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -4,6 +4,8 @@ import Profile, { ProfileProps } from "@/entities/user/ui/card/Profile";
 import PostCard from "@/entities/post/ui/card/PostCard";
 import Tab from "@/widgets/mypage/ui/Tab.tsx/Tab";
 import { apiFetch } from "@/shared/api/fetcher";
+import { Modal } from "@/shared/ui/Modal/Modal";
+import { ProfileEditModal } from "@/features/editProfile/ui/ProfileEditModal/ProfileEditModal";
 
 const options = [
   { label: "판매중 상품", value: "selling" },
@@ -67,24 +69,32 @@ const Mypage = () => {
   const [selected, setSelected] = useState(options[0].value);
   const [userProfile, setUserProfile] = useState<ProfileProps | null>(null);
 
-  useEffect(() => {
-    const fetchUserProfile = async () => {
-      try {
-        const data = await apiFetch<ProfileProps>("/api/users/me", {
-          method: "GET",
-        });
-        setUserProfile(data);
-      } catch (error) {
-        console.error("유저 정보 로딩 실패: ", error);
-      }
-    };
+  // 모달 상태
+  const [modalType, setModalType] = useState<
+    null | "edit" | "success" | "error"
+  >(null);
+  const isAnyModalOpen = modalType !== null;
 
+  async function fetchUserProfile() {
+    try {
+      const data = await apiFetch<ProfileProps>("/api/users/me", {
+        method: "GET",
+      });
+      setUserProfile(data);
+    } catch (error) {
+      console.error("유저 정보 로딩 실패: ", error);
+    }
+  }
+
+  useEffect(() => {
     fetchUserProfile();
   }, []);
 
   return (
     <main className="m-auto flex max-w-[335px] flex-col items-center justify-center gap-[60px] pt-[30px] md:max-w-[510px] md:pt-[40px] xl:max-w-[1340px] xl:flex-row xl:items-start xl:justify-start xl:gap-[80px] xl:pt-[60px]">
-      {userProfile && <Profile {...userProfile} />}
+      {userProfile && (
+        <Profile {...userProfile} onEdit={() => setModalType("edit")} />
+      )}
       <section className="flex flex-col gap-[30px]">
         <Tab options={options} selected={selected} onChange={setSelected} />
         <ul className="grid grid-cols-2 gap-[15px] xl:grid-cols-3 xl:gap-[20px]">
@@ -95,6 +105,41 @@ const Mypage = () => {
           ))}
         </ul>
       </section>
+
+      {isAnyModalOpen && (
+        <div className="pointer-events-auto fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          {modalType === "edit" && userProfile && (
+            <ProfileEditModal
+              {...userProfile}
+              onClose={() => setModalType(null)}
+              onSave={async () => {
+                setModalType(null);
+                setTimeout(() => setModalType("success"), 50);
+                await fetchUserProfile(); // 최신 데이터 갱신
+              }}
+              onError={() => setModalType("error")}
+            />
+          )}
+
+          {modalType === "success" && (
+            <Modal
+              message="프로필이 성공적으로 수정되었습니다."
+              buttonText="확인"
+              onClick={() => setModalType(null)}
+              className=""
+            />
+          )}
+
+          {modalType === "error" && (
+            <Modal
+              message="프로필 수정에 실패했습니다."
+              buttonText="확인"
+              onClick={() => setModalType(null)}
+              className=""
+            />
+          )}
+        </div>
+      )}
     </main>
   );
 };

--- a/src/entities/user/ui/card/Profile.tsx
+++ b/src/entities/user/ui/card/Profile.tsx
@@ -14,6 +14,7 @@ export interface ProfileProps {
   category?: string;
   sellCount: number;
   buyCount: number;
+  onEdit?: () => void;
 }
 
 const Profile = ({
@@ -23,6 +24,7 @@ const Profile = ({
   category,
   sellCount,
   buyCount,
+  onEdit,
 }: ProfileProps) => {
   const router = useRouter();
   const { logout } = useAuthStore();
@@ -72,7 +74,9 @@ const Profile = ({
         </div>
 
         <div className="flex w-full flex-col gap-[10px] md:gap-[15px] lg:gap-[20px]">
-          <Button className="w-full md:w-full xl:w-full">프로필 편집</Button>
+          <Button className="w-full md:w-full xl:w-full" onClick={onEdit}>
+            프로필 편집
+          </Button>
           <Button
             variant="tertiary"
             className="w-full md:w-full xl:w-full"

--- a/src/shared/ui/Modal/Modal.tsx
+++ b/src/shared/ui/Modal/Modal.tsx
@@ -8,7 +8,7 @@ interface ModalProps {
   message: string;
   buttonText?: string;
   onClick: () => void;
-  className: string;
+  className?: string;
 }
 
 export const Modal = ({
@@ -18,19 +18,19 @@ export const Modal = ({
   className,
 }: ModalProps) => {
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div
         className={cn(
-          "bg-black-900 rounded-lg shadow-lg flex flex-col items-center justify-center gap-10 p-6 text-center",
-          "w-[320px] h-[180px]",
-          "md:w-[420px] md:h-[190px]",
-          "xl:w-[500px] xl:h-[200px]",
+          "bg-black-900 flex flex-col items-center justify-center gap-10 rounded-lg p-6 text-center shadow-lg",
+          "h-[180px] w-[320px]",
+          "md:h-[190px] md:w-[420px]",
+          "xl:h-[200px] xl:w-[500px]",
           className,
         )}
       >
         <p
           className={cn(
-            "text-white whitespace-pre-line",
+            "whitespace-pre-line text-white",
             "text-[14px] md:text-[16px] xl:text-[18px]",
           )}
         >


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #55

## 📝작업 내용

> 프로필 
 - props명 api에 맞게 수정
 - 유저 정보 조회 api 연동

> 마이페이지 
 -  판매내역/구매내역과 카테고리 줄 구분
 - 프로필 수정 모달, 프로필 수정 완료 모달, 프로필 수정 실패 모달 적용

### 스크린샷 (선택)
<img width="356" height="751" alt="image" src="https://github.com/user-attachments/assets/8c434f15-e6eb-4020-9437-4a32bde87da4" />
<img width="627" height="894" alt="image" src="https://github.com/user-attachments/assets/1b6af2c7-f590-425c-9a89-371ebf4645fd" />


## 💬리뷰 요구사항(선택)

> 리뷰어에게 미리 알려야 할 사항이 있다면 여기에 작성해주세요.
프로필 이미지가 데스크톱, 태블릿/모바일에서 다른 모양으로 표현되는데 확인 부탁드립니다!