### PR TITLE
fix: 회원가입 요청 endpoint 및 에러 메시지 변경

### DIFF
--- a/src/features/auth/ui/SignUpForm/SignUpForm.tsx
+++ b/src/features/auth/ui/SignUpForm/SignUpForm.tsx
@@ -121,13 +121,6 @@ export const SignUpForm = ({ onSuccess, onError }: SignUpFormProps) => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     console.log("회원가입 요청 폼 제출");
-    const res = await apiFetch<{
-      status: string;
-    }>("/health", {
-      method: "GET",
-      noAuth: true,
-    });
-    console.log(res);
     try {
       const body = {
         email,
@@ -139,14 +132,7 @@ export const SignUpForm = ({ onSuccess, onError }: SignUpFormProps) => {
       };
 
       console.log(body);
-      const res = await apiFetch<{
-        userId: number;
-        email: string;
-        nickname: string;
-        birthDate: string;
-        createdAt: string;
-        updatedAt: string;
-      }>("/auth/signup", {
+      const res = await apiFetch("/api/users/", {
         method: "POST",
         body: JSON.stringify(body),
         noAuth: true,
@@ -158,9 +144,9 @@ export const SignUpForm = ({ onSuccess, onError }: SignUpFormProps) => {
       console.error("회원가입 실패:", error + "\n");
       if (error instanceof Error) {
         // 서버 에러 메시지 처리
-        if (error.message.includes("isEmailUsed")) {
+        if (error.message.includes("EMAIL_DUPLICATE")) {
           setEmailError("이미 사용 중인 이메일입니다.");
-        } else if (error.message.includes("isNicknameUsed")) {
+        } else if (error.message.includes("NICKNAME_DUPLICATE")) {
           setNicknameError("이미 사용 중인 닉네임입니다.");
         } else {
           onError?.("회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.");


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 회원가입 요청시 에러 발생 -> 서버의 엔드포인트 / 이메일 중복, 닉네임 중복 시 에러 메시지 변경으로 서버 설정에 맞게 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어에게 미리 알려야 할 사항이 있다면 여기에 작성해주세요.
